### PR TITLE
Initialization of .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+#Authorization token for ballchasing api
+key.txt
+
+#node modules
+node_modules


### PR DESCRIPTION
Prevents ball chasing api authentication token file to be added as well as node modules